### PR TITLE
Port the cluster reads tool to click

### DIFF
--- a/src/pore_c/cli.py
+++ b/src/pore_c/cli.py
@@ -1,6 +1,7 @@
 import click
 import os.path
 from pore_c.tools.generate_fragments import fragment_generator
+from pore_c.tools.cluster_reads import cluster_reads as cluster_reads_tool
 
 
 class NaturalOrderGroup(click.Group):
@@ -63,16 +64,17 @@ def generate_fragments(reference_fasta, restriction_pattern, outfile):
             seq_match_pos.seq_length
         ))
 
-@cli.command(short_help="Map the reads against a reference genome")
-@click.argument('bam', type=click.Path(exists=True))
-def map_reads(bam):
-    print(bam)
 
 
 @cli.command(short_help="Cluster mappings by read")
-@click.argument('bam', type=click.Path(exists=True))
-def cluster_reads(bam):
-    print(bam)
+@click.argument('input_bam', type=click.Path(exists=True))
+@click.argument('keep_bam', type=click.Path(exists=False))
+@click.argument('discard_bam', type=click.Path(exists=False))
+@click.option("--trim", default=20, type=int, help="The number of bases to ignore at the end of each aligned segment when calculating overlaps")
+@click.option("--mapping_quality_cutoff", default=0, type=int, help="The minimum mapping quality for a alignment segment to be kept")
+def cluster_reads(input_bam, keep_bam, discard_bam, trim, mapping_quality_cutoff):
+    num_reads, num_reads_kept, num_aligns, num_aligns_kept = cluster_reads_tool(input_bam, keep_bam, discard_bam, trim, mapping_quality_cutoff)
+    print(num_reads, num_reads_kept, num_aligns, num_aligns_kept)
 
 
 @cli.command()

--- a/src/pore_c/tools/cluster_reads.py
+++ b/src/pore_c/tools/cluster_reads.py
@@ -1,0 +1,73 @@
+import sys
+from typing import Tuple
+import numpy as np
+from pysam import AlignmentFile
+from intervaltree import IntervalTree
+
+
+
+def read_mappings_iter(bam, mapping_quality_cutoff=0):
+    aligns = []
+    current_read_name = None
+    for align in bam:
+        if align.is_unmapped:
+            continue
+        if current_read_name is None:
+            current_read_name = align.query_name
+            aligns.append(align)
+        elif current_read_name == align.query_name:
+            aligns.append(align)
+        else:
+            yield aligns
+            current_read_name = align.query_name
+            aligns = [align]
+    yield aligns
+
+def cluster_aligned_segments(aligns, trim, mapping_quality_cutoff=0):
+    if len(aligns) == 1:
+        return []
+    intervals = [
+        (align.query_alignment_start + trim, align.query_alignment_end - trim, x)
+        for x, align in enumerate(aligns)
+        if align.mapping_quality >= mapping_quality_cutoff
+    ]
+    tree = IntervalTree.from_tuples(intervals)
+    tree.merge_overlaps(data_initializer=[], data_reducer=lambda x, y: x + [y])
+
+    if len(tree) == 1:
+        return []
+
+    keep = []
+    for interval in tree:
+        indices = interval.data
+        scores = np.array([aligns[x].get_tag("AS") for x in indices])
+        #TODO: implement a threshold between best and second best scores to remove ambiguous mappings
+        best_read = np.argmax(scores)
+        keep.append(indices[best_read])
+    return sorted(keep)
+
+
+def cluster_reads(input_bam: str, keep_bam: str, discard_bam: str, trim: int, mapping_quality_cutoff: int) -> Tuple[int, int, int, int]:
+
+    bam_in = AlignmentFile(input_bam)
+    bam_keep = AlignmentFile(keep_bam, 'wb', template=bam_in)
+    bam_discard = AlignmentFile(discard_bam, 'wb', template=bam_in)
+
+    num_reads = 0
+    num_reads_kept = 0
+    num_aligns = 0
+    num_aligns_kept = 0
+    for read_aligns in read_mappings_iter(bam_in):
+        num_reads += 1
+        num_aligns += len(read_aligns)
+        keep= cluster_aligned_segments(read_aligns, trim, mapping_quality_cutoff)
+        if not keep:
+            continue
+        num_reads_kept += 1
+        for idx, align in enumerate(read_aligns):
+            if idx in keep:
+                bam_keep.write(read_aligns[idx])
+            else:
+                bam_discard.write(read_aligns[idx])
+        num_aligns_kept += len(keep)
+    return (num_reads, num_reads_kept, num_aligns, num_aligns_kept)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from pysam import AlignmentFile
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="function")
+def namesorted_align_file():
+    af = AlignmentFile(DATA_DIR / "test_ns.sam")
+    return af
+

--- a/tests/end_to_end/Snakefile
+++ b/tests/end_to_end/Snakefile
@@ -24,6 +24,8 @@ REF_BWA_INDEX = REF_FASTA.with_suffix(".gz.bwt")
 FRAG_FILE = REF_FASTA.with_suffix(".{enzyme}.hicREF")
 
 MAPPED_BAM = WORK_DIR / "{sample_id}_{ref_id}_{mapping_params}.ns.bam"
+FILTERED_BAM = WORK_DIR / "{sample_id}_{ref_id}_{mapping_params}.keep.bam"
+DISCARDED_BAM = WORK_DIR / "{sample_id}_{ref_id}_{mapping_params}.discard.bam"
 
 wildcard_constraints:
   ref_id="\S+_\S+"
@@ -32,7 +34,19 @@ wildcard_constraints:
 rule all:
     input: 
       frag_file = expand(str(FRAG_FILE), enzyme=ENZYME, ref_id=REF_ID),
-      mapping = expand(str(MAPPED_BAM), sample_id=SAMPLE_ID, ref_id=REF_ID, mapping_params="MC4C")
+      mapping = expand(str(FILTERED_BAM), sample_id=SAMPLE_ID, ref_id=REF_ID, mapping_params="MC4C")
+
+
+rule filter_bam:
+  output: 
+    keep=FILTERED_BAM,
+    discard=DISCARDED_BAM
+  input: MAPPED_BAM
+  params:
+    trim=20,
+    mapping_quality_cutoff=0
+  shell:
+    "pore_c cluster_reads {input} {output.keep} {output.discard} --trim {params.trim} --mapping_quality_cutoff {params.mapping_quality_cutoff}"
 
 
 rule bwa_map_reads:

--- a/tests/test_cluster_reads.py
+++ b/tests/test_cluster_reads.py
@@ -1,0 +1,16 @@
+import pytest
+from pore_c.tools.cluster_reads import read_mappings_iter, cluster_aligned_segments
+
+
+def test_read_mappings_iter(namesorted_align_file):
+    res = [len(aligns) for aligns in read_mappings_iter(namesorted_align_file)]
+    assert(res == [2, 5, 6, 5, 2, 1])
+
+
+def test_cluster_aligned_segments(namesorted_align_file):
+
+    aligns = list(namesorted_align_file)[2:7]
+    keep = cluster_aligned_segments(aligns, 20)
+    assert(keep == [0, 1, 3])
+
+


### PR DESCRIPTION
Some other changes:
- use intervaltree to find overlapping intervals on read
- add a mapping quality filter to remove alignments that bwa thinks are
ambiguous
- added end-to-end tests