### PR TITLE
added mean qscore calculation to fastq parquet generation

### DIFF
--- a/src/pore_c/analyses/reads.py
+++ b/src/pore_c/analyses/reads.py
@@ -92,7 +92,7 @@ def filter_records(list_of_records, min_read_length, max_read_length):
     df = (
         pd.DataFrame([(_.name, mean_fastq_quality(_.get_quality_array()), len(_.sequence)) for _ in list_of_records], columns=["read_id", "mean_qscore","read_length"])        
         .astype({"read_length": pd.np.uint32})
-        .astype({"mean_qscore": pd.np.uint32})        
+        .astype({"mean_qscore": pd.np.float16})        
         .eval("pass_filter = (@min_read_length <= read_length < @max_read_length)")
     )
     seq_strings = {True: [], False: []}

--- a/src/pore_c/analyses/reads.py
+++ b/src/pore_c/analyses/reads.py
@@ -9,7 +9,7 @@ from streamz import Stream
 
 from pore_c.datasources import Fastq
 from pore_c.io import FastqWriter
-from pore_c.utils import DataFrameProgress
+from pore_c.utils import DataFrameProgress, mean_fastq_quality
 
 logger = getLogger(__name__)
 
@@ -87,15 +87,12 @@ def filter_fastq(
     return summary_stats
 
 
-
-def fastq_quality(qual_array):
-    return -10. * math.log(sum([10.**(-x / 10.) for x in qual_array]) / len(qual_array),10)
-
 def filter_records(list_of_records, min_read_length, max_read_length):
 
     df = (
-        pd.DataFrame([(_.name, fastq_quality(_.get_quality_array()), len(_.sequence)) for _ in list_of_records], columns=["read_id", "mean_qscore","read_length"])        
+        pd.DataFrame([(_.name, mean_fastq_quality(_.get_quality_array()), len(_.sequence)) for _ in list_of_records], columns=["read_id", "mean_qscore","read_length"])        
         .astype({"read_length": pd.np.uint32})
+        .astype({"mean_qscore": pd.np.uint32})        
         .eval("pass_filter = (@min_read_length <= read_length < @max_read_length)")
     )
     seq_strings = {True: [], False: []}

--- a/src/pore_c/analyses/reads.py
+++ b/src/pore_c/analyses/reads.py
@@ -1,3 +1,4 @@
+import math 
 import sys
 from logging import getLogger
 from pathlib import Path
@@ -86,10 +87,14 @@ def filter_fastq(
     return summary_stats
 
 
+
+def fastq_quality(qual_array):
+    return -10. * math.log(sum([10.**(-x / 10.) for x in qual_array]) / len(qual_array),10)
+
 def filter_records(list_of_records, min_read_length, max_read_length):
 
     df = (
-        pd.DataFrame([(_.name, len(_.sequence)) for _ in list_of_records], columns=["read_id", "read_length"])
+        pd.DataFrame([(_.name, fastq_quality(_.get_quality_array()), len(_.sequence)) for _ in list_of_records], columns=["read_id", "mean_qscore","read_length"])        
         .astype({"read_length": pd.np.uint32})
         .eval("pass_filter = (@min_read_length <= read_length < @max_read_length)")
     )

--- a/src/pore_c/utils.py
+++ b/src/pore_c/utils.py
@@ -1,4 +1,5 @@
 import re
+import math
 
 from tqdm import tqdm
 
@@ -27,6 +28,9 @@ class DataFrameProgress(object):
     def save(self, path):
         self._data.to_csv(path, index=False)
 
+
+def mean_fastq_quality(qual_array):
+    return -10. * math.log(sum([10.**(-x / 10.) for x in qual_array]) / len(qual_array),10)
 
 def kmg_bases_to_int(value: str) -> int:
     try:


### PR DESCRIPTION
Added a third column to pore-c catalog parquet file which calculates the mean qscore over the length of each read. Tested against seqkit v0.11.0 fx2tab -q results.